### PR TITLE
Ring Indexing

### DIFF
--- a/src/main/java/org/templegalaxia/GalaxiaGui.java
+++ b/src/main/java/org/templegalaxia/GalaxiaGui.java
@@ -10,6 +10,7 @@ import org.templegalaxia.model.Temple;
 import org.templegalaxia.patterns.gerald.*;
 import org.templegalaxia.patterns.matty.*;
 import org.templegalaxia.patterns.ping.Swirl;
+import org.templegalaxia.patterns.ted.RingTest;
 import org.templegalaxia.patterns.testing.*;
 import processing.core.PApplet;
 
@@ -65,6 +66,7 @@ public class GalaxiaGui extends PApplet {
     lx.registerPattern(Sparkle.class);
     lx.registerPattern(DebugOrder.class);
     lx.registerPattern(Swirl.class);
+    lx.registerPattern(RingTest.class);
   }
 
   public void draw() {

--- a/src/main/java/org/templegalaxia/model/Petal.java
+++ b/src/main/java/org/templegalaxia/model/Petal.java
@@ -13,7 +13,7 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
 public class Petal extends LXModel {
-  public static final int NUM_PIXELS;
+  public static final int numPixels;
 
   public Petal(LXTransform transform) {
     super(new Fixture(transform));
@@ -50,7 +50,7 @@ public class Petal extends LXModel {
 
       System.out.println(String.format("Loaded %d points.", xyzs.size()));
     }
-    NUM_PIXELS = xyzs.size();
+    numPixels = xyzs.size();
   }
 
   private static class Fixture extends LXAbstractFixture {

--- a/src/main/java/org/templegalaxia/model/Ring.java
+++ b/src/main/java/org/templegalaxia/model/Ring.java
@@ -1,0 +1,25 @@
+package org.templegalaxia.model;
+
+import heronarts.lx.model.LXPoint;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Ring {
+  private List<LXPoint> points;
+
+  Ring(int size) {
+    points = new ArrayList<LXPoint>(size);
+  }
+
+  public void addPoint(LXPoint point) {
+    points.add(point);
+  }
+
+  public List<LXPoint> getPoints() {
+    return points;
+  }
+
+  public LXPoint getPoint(int idx) {
+    return points.get(idx);
+  }
+}

--- a/src/main/java/org/templegalaxia/model/Ring.java
+++ b/src/main/java/org/templegalaxia/model/Ring.java
@@ -1,23 +1,12 @@
 package org.templegalaxia.model;
 
+import heronarts.lx.model.LXAbstractFixture;
+import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Ring {
-  private List<LXPoint> points;
-
-  Ring(int size) {
-    points = new ArrayList<LXPoint>(size);
-  }
-
-  public void addPoint(LXPoint point) {
-    points.add(point);
-  }
-
-  public List<LXPoint> getPoints() {
-    return points;
-  }
+public class Ring extends LXAbstractFixture {
 
   public LXPoint getPoint(int idx) {
     return points.get(idx);

--- a/src/main/java/org/templegalaxia/model/Ring.java
+++ b/src/main/java/org/templegalaxia/model/Ring.java
@@ -1,14 +1,29 @@
 package org.templegalaxia.model;
 
 import heronarts.lx.model.LXAbstractFixture;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Ring extends LXAbstractFixture {
+  private Map<LXPoint, Integer> pixelIdxMap = new HashMap<LXPoint, Integer>();
 
-  public LXPoint getPoint(int idx) {
-    return points.get(idx);
+  public LXAbstractFixture addIndexedPoint(LXPoint lxPoint, int pixelIndex) {
+    pixelIdxMap.put(lxPoint, pixelIndex);
+    return super.addPoint(lxPoint);
+  }
+
+  public int getPixelIndex() {
+    return getPixelIndex();
+  }
+
+  /**
+   * Return the pixel index associated with the given point.
+   *
+   * @param lxPoint
+   * @return Index in the point in absolute model space (i.e. the index in the Model.colors array)
+   */
+  public int getPixelIndex(LXPoint lxPoint) {
+    return pixelIdxMap.get(lxPoint);
   }
 }

--- a/src/main/java/org/templegalaxia/model/Temple.java
+++ b/src/main/java/org/templegalaxia/model/Temple.java
@@ -9,7 +9,7 @@ import java.util.List;
 import processing.core.PApplet;
 
 public class Temple extends LXModel {
-  private static final float NUMBER_OF_PETALS = 20;
+  private static final int NUMBER_OF_PETALS = 20;
   private static final float ANGLE_BETWEEN_PETALS = PApplet.radians(360 / NUMBER_OF_PETALS);
 
   public final List<Petal> petals;
@@ -22,14 +22,24 @@ public class Temple extends LXModel {
 
   private static class Fixture extends LXAbstractFixture {
     private final List<Petal> petals = new ArrayList<>();
+    private final List<Ring> rings = new ArrayList<Ring>();
 
     Fixture(PApplet applet) {
       LXTransform transform = new LXTransform();
+      int pixelsPerPetal = new Petal(transform).numPixels;
+      for (int i = 0; i < pixelsPerPetal; i++) {
+        rings.add(new Ring(NUMBER_OF_PETALS));
+      }
 
       for (int i = 0; i < NUMBER_OF_PETALS; ++i) {
         Petal petal = new Petal(transform);
         addPoints(petal);
         this.petals.add(petal);
+
+        petal.getPoints().forEach((point) -> {});
+        for (int j = 0; j < petal.getPoints().size(); j++) {
+          rings.get(j).addPoint(petal.getPoints().get(j));
+        }
 
         transform.rotateY(ANGLE_BETWEEN_PETALS);
       }

--- a/src/main/java/org/templegalaxia/model/Temple.java
+++ b/src/main/java/org/templegalaxia/model/Temple.java
@@ -27,22 +27,24 @@ public class Temple extends LXModel {
     Fixture(PApplet applet) {
       LXTransform transform = new LXTransform();
       int pixelsPerPetal = new Petal(transform).numPixels;
-      for (int i = 0; i < pixelsPerPetal; i++) {
-        rings.add(new Ring(NUMBER_OF_PETALS));
-      }
 
       for (int i = 0; i < NUMBER_OF_PETALS; ++i) {
         Petal petal = new Petal(transform);
         addPoints(petal);
         this.petals.add(petal);
 
-        petal.getPoints().forEach((point) -> {});
-        for (int j = 0; j < petal.getPoints().size(); j++) {
-          rings.get(j).addPoint(petal.getPoints().get(j));
-        }
-
         transform.rotateY(ANGLE_BETWEEN_PETALS);
       }
+
+      // Reindex points into rings of the same height.
+      for (int i = 0; i < pixelsPerPetal; i++) {
+        Ring ring = new Ring();
+        for (Petal petal : petals) {
+          ring.addPoint(petal.getPoints().get(i));
+        }
+        rings.add(ring);
+      }
+
     }
   }
 }

--- a/src/main/java/org/templegalaxia/model/Temple.java
+++ b/src/main/java/org/templegalaxia/model/Temple.java
@@ -2,10 +2,12 @@ package org.templegalaxia.model;
 
 import heronarts.lx.model.LXAbstractFixture;
 import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
 import heronarts.lx.transform.LXTransform;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.templegalaxia.patterns.TemplePattern;
 import processing.core.PApplet;
 
 public class Temple extends LXModel {
@@ -13,11 +15,13 @@ public class Temple extends LXModel {
   private static final float ANGLE_BETWEEN_PETALS = PApplet.radians(360 / NUMBER_OF_PETALS);
 
   public final List<Petal> petals;
+  public final List<Ring> rings;
 
   public Temple(PApplet applet) {
     super(new Fixture(applet));
     Fixture f = (Fixture) this.fixtures.get(0);
     this.petals = Collections.unmodifiableList(f.petals);
+    this.rings = Collections.unmodifiableList(f.rings);
   }
 
   private static class Fixture extends LXAbstractFixture {
@@ -39,13 +43,15 @@ public class Temple extends LXModel {
       // Reindex points into rings of the same height.
       for (int i = 0; i < pixelsPerPetal; i++) {
         Ring ring = new Ring();
-        for (Petal petal : petals) {
-          ring.addPoint(petal.getPoints().get(i));
+        for (int j = 0; j < petals.size(); j++) {
+          Petal petal = petals.get(j);
+          LXPoint point = petal.getPoints().get(i);
+          int pixelIdx = TemplePattern.petalIndexToPointIndex(i, j);
+          ring.addIndexedPoint(point, pixelIdx);
         }
         rings.add(ring);
       }
       assert rings.size() == petals.get(0).size;
-
     }
   }
 }

--- a/src/main/java/org/templegalaxia/model/Temple.java
+++ b/src/main/java/org/templegalaxia/model/Temple.java
@@ -26,14 +26,14 @@ public class Temple extends LXModel {
 
     Fixture(PApplet applet) {
       LXTransform transform = new LXTransform();
-      int pixelsPerPetal = new Petal(transform).numPixels;
+      int pixelsPerPetal = -1;
 
       for (int i = 0; i < NUMBER_OF_PETALS; ++i) {
         Petal petal = new Petal(transform);
         addPoints(petal);
         this.petals.add(petal);
-
         transform.rotateY(ANGLE_BETWEEN_PETALS);
+        if (pixelsPerPetal == -1) pixelsPerPetal = petal.size;
       }
 
       // Reindex points into rings of the same height.
@@ -44,6 +44,7 @@ public class Temple extends LXModel {
         }
         rings.add(ring);
       }
+      assert rings.size() == petals.get(0).size;
 
     }
   }

--- a/src/main/java/org/templegalaxia/patterns/TemplePattern.java
+++ b/src/main/java/org/templegalaxia/patterns/TemplePattern.java
@@ -21,7 +21,7 @@ public abstract class TemplePattern extends LXPattern {
     return pointIndex / Petal.numPixels;
   }
 
-  public int petalIndexToPointIndex(int petalIndex, int petalNumber) {
+  public static int petalIndexToPointIndex(int petalIndex, int petalNumber) {
     return (petalNumber * Petal.numPixels) + petalIndex;
   }
 }

--- a/src/main/java/org/templegalaxia/patterns/TemplePattern.java
+++ b/src/main/java/org/templegalaxia/patterns/TemplePattern.java
@@ -14,14 +14,14 @@ public abstract class TemplePattern extends LXPattern {
   }
 
   public int pointIndexToPetalIndex(int pointIndex) {
-    return pointIndex % Petal.NUM_PIXELS;
+    return pointIndex % Petal.numPixels;
   }
 
   public int pointIndexToPetalNumber(int pointIndex) {
-    return pointIndex / Petal.NUM_PIXELS;
+    return pointIndex / Petal.numPixels;
   }
 
   public int petalIndexToPointIndex(int petalIndex, int petalNumber) {
-    return (petalNumber * Petal.NUM_PIXELS) + petalIndex;
+    return (petalNumber * Petal.numPixels) + petalIndex;
   }
 }

--- a/src/main/java/org/templegalaxia/patterns/gerald/PetalChase.java
+++ b/src/main/java/org/templegalaxia/patterns/gerald/PetalChase.java
@@ -16,7 +16,7 @@ public class PetalChase extends TemplePattern {
   private double lfoPosition = 0;
 
   private BoundedParameter blurParam =
-      new BoundedParameter("blurParam", Petal.NUM_PIXELS / 6, 1, Petal.NUM_PIXELS / 2)
+      new BoundedParameter("blurParam", Petal.numPixels / 6, 1, Petal.numPixels / 2)
           .setDescription("Distance of trailing lights");
 
   private BoundedParameter speedParam =
@@ -25,7 +25,7 @@ public class PetalChase extends TemplePattern {
   private BoundedParameter jitterParam =
       new BoundedParameter("Jitter", 1, 1, 3).setDescription("Jitter the lights on each petal");
 
-  private SinLFO pixelLFO = new SinLFO(0, Petal.NUM_PIXELS, speedParam);
+  private SinLFO pixelLFO = new SinLFO(0, Petal.numPixels, speedParam);
 
   public PetalChase(LX lx) {
     super(lx);
@@ -44,7 +44,7 @@ public class PetalChase extends TemplePattern {
     int remapPixel =
         (int)
             PApplet.map(
-                (float) currentPixel, 0, Petal.NUM_PIXELS, -blurVal, Petal.NUM_PIXELS + blurVal);
+                (float) currentPixel, 0, Petal.numPixels, -blurVal, Petal.numPixels + blurVal);
 
     // Determine the oscilators direction, store currentPixel for the next run
     double lfoDirection = Math.signum(currentPixel - lfoPosition);
@@ -74,7 +74,7 @@ public class PetalChase extends TemplePattern {
                 }
 
                 // Ensure that the blurPixel is a pixel in reality
-                if (0 <= blurPixel && blurPixel < Petal.NUM_PIXELS) {
+                if (0 <= blurPixel && blurPixel < Petal.numPixels) {
                   int pointIndex = petalIndexToPointIndex(blurPixel, petalNum);
 
                   // Modify brightness based on the distance form the zeroth point

--- a/src/main/java/org/templegalaxia/patterns/ted/RingTest.java
+++ b/src/main/java/org/templegalaxia/patterns/ted/RingTest.java
@@ -1,0 +1,51 @@
+package org.templegalaxia.patterns.ted;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.modulator.SinLFO;
+import heronarts.lx.parameter.BoundedParameter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.templegalaxia.model.Ring;
+import org.templegalaxia.patterns.TemplePattern;
+
+@LXCategory("Test")
+public class RingTest extends TemplePattern {
+  double period = 1000.0; // one second
+
+  private BoundedParameter speedParam =
+      new BoundedParameter("Speed", 2500, 5000, 200).setDescription("Speed of chase");
+
+  private SinLFO ringLFO = new SinLFO(0, model.rings.size() - 1, speedParam);
+  private Set<Integer> selectedPointIndexes = new HashSet<Integer>();
+
+  public RingTest(LX lx) {
+    super(lx);
+    addModulator(ringLFO).trigger();
+    addParameter(speedParam);
+  }
+
+  @Override
+  protected void run(double deltaMs) {
+    int selectedIdx = Math.round(ringLFO.getValuef());
+    List<Ring> rings = model.rings;
+    assert selectedIdx < rings.size();
+    Ring selectedRing = rings.get(selectedIdx);
+
+    selectedPointIndexes.clear();
+    for (LXPoint point : selectedRing.getPoints()) {
+      int idx = selectedRing.getPixelIndex(point);
+      selectedPointIndexes.add(idx);
+    }
+    for (int i = 0; i < colors.length; i++) {
+      if (selectedPointIndexes.contains(i)) {
+        colors[i] = LXColor.hsb(0, 0, 100);
+      } else {
+        colors[i] = LXColor.BLACK;
+      }
+    }
+  }
+}


### PR DESCRIPTION
In addition to petal-based access, this indexes all the pixels by horizontal rings, to allow ring-based iteration.

Each ring object stores a map from each of its points back to that point's index in absolute pixel space.

Includes a demo patter: `RingTest`